### PR TITLE
[#21] Traverse the object hierarchy when attempting to resolve the `WithHttpStatus` and `HasUserMessage` attributes in the `WrappedException`

### DIFF
--- a/src/Exception/WrappedException.php
+++ b/src/Exception/WrappedException.php
@@ -9,7 +9,6 @@ use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Validator\Exception\ValidationFailedException;
 
 use function array_push;
-use function array_shift;
 use function intval;
 use function is_string;
 use function max;
@@ -224,26 +223,12 @@ final readonly class WrappedException implements WrappedExceptionInterface
         $class = new \ReflectionClass($this->exception);
 
         do {
-            $attributes = $class->getAttributes($attributeClass, \ReflectionAttribute::IS_INSTANCEOF);
-
-            if ($attribute = array_shift($attributes)) {
-                return $attribute->newInstance();
+            if ($attributes = $class->getAttributes($attributeClass, \ReflectionAttribute::IS_INSTANCEOF)) {
+                return $attributes[0]->newInstance();
             }
         } while ($class = $class->getParentClass());
 
         return null;
-
-        /*
-        $attributes = new \ReflectionClass($this->exception)->getAttributes(
-            $attributeClass, \ReflectionAttribute::IS_INSTANCEOF
-        );
-
-        if ($attribute = array_shift($attributes)) {
-            return $attribute->newInstance();
-        }
-
-        return null;
-        */
     }
 
     /**

--- a/src/Exception/WrappedException.php
+++ b/src/Exception/WrappedException.php
@@ -221,6 +221,19 @@ final readonly class WrappedException implements WrappedExceptionInterface
      */
     private function getAttribute(string $attributeClass): ?object
     {
+        $class = new \ReflectionClass($this->exception);
+
+        do {
+            $attributes = $class->getAttributes($attributeClass, \ReflectionAttribute::IS_INSTANCEOF);
+
+            if ($attribute = array_shift($attributes)) {
+                return $attribute->newInstance();
+            }
+        } while ($class = $class->getParentClass());
+
+        return null;
+
+        /*
         $attributes = new \ReflectionClass($this->exception)->getAttributes(
             $attributeClass, \ReflectionAttribute::IS_INSTANCEOF
         );
@@ -230,6 +243,7 @@ final readonly class WrappedException implements WrappedExceptionInterface
         }
 
         return null;
+        */
     }
 
     /**

--- a/tests/Exception/AbstractException.php
+++ b/tests/Exception/AbstractException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace OneToMany\RichBundle\Tests\Exception;
+
+use Symfony\Component\HttpKernel\Attribute\WithHttpStatus;
+
+#[WithHttpStatus(401)]
+abstract class AbstractException extends \RuntimeException
+{
+}


### PR DESCRIPTION
**Issues**
- #21 