### PR TITLE
[#27] Add a `getName()` method to `JsonSchemaInterface` and `AbstractJsonSchema` which returns the name of the schema class by default

### DIFF
--- a/src/Contract/AbstractJsonSchema.php
+++ b/src/Contract/AbstractJsonSchema.php
@@ -3,6 +3,7 @@
 namespace OneToMany\RichBundle\Contract;
 
 use function json_encode;
+use function strval;
 
 abstract readonly class AbstractJsonSchema implements JsonSchemaInterface
 {
@@ -12,6 +13,12 @@ abstract readonly class AbstractJsonSchema implements JsonSchemaInterface
 
     public function __toString(): string
     {
-        return (string) json_encode(static::schema());
+        return strval(json_encode(static::schema()));
+    }
+
+    public function getName(): string
+    {
+        /** @var non-empty-string */
+        return new \ReflectionClass($this)->getShortName();
     }
 }

--- a/src/Contract/JsonSchemaInterface.php
+++ b/src/Contract/JsonSchemaInterface.php
@@ -2,18 +2,17 @@
 
 namespace OneToMany\RichBundle\Contract;
 
-interface JsonSchemaInterface
+interface JsonSchemaInterface extends \Stringable
 {
     public function __toString(): string;
 
     /**
-     * @return array{
-     *   title: non-empty-string,
-     *   type: non-empty-string,
-     *   properties: array<string, mixed>,
-     *   required: list<non-empty-string>,
-     *   additionalProperties: bool,
-     * }
+     * @return array<string, mixed>
      */
     public static function schema(): array;
+
+    /**
+     * @return non-empty-string
+     */
+    public function getName(): string;
 }

--- a/tests/Contract/AbstractJsonSchemaTest.php
+++ b/tests/Contract/AbstractJsonSchemaTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OneToMany\RichBundle\Tests\Contract;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\TestCase;
+
+#[Group('UnitTests')]
+#[Group('ContractTests')]
+final class AbstractJsonSchemaTest extends TestCase
+{
+    public function testGettingNameReturnsShortClassNameByDefault(): void
+    {
+        $this->assertEquals('TestSchema', new TestSchema()->getName());
+    }
+}

--- a/tests/Contract/TestSchema.php
+++ b/tests/Contract/TestSchema.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace OneToMany\RichBundle\Tests\Contract;
+
+use OneToMany\RichBundle\Contract\AbstractJsonSchema;
+
+final readonly class TestSchema extends AbstractJsonSchema
+{
+    public static function schema(): array
+    {
+        $schema = [
+            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            'title' => 'Test',
+            'type' => 'object',
+            'properties' => [
+                'id' => [
+                    'type' => 'integer',
+                ],
+                'name' => [
+                    'type' => 'string',
+                ],
+            ],
+            'required' => [
+                'id',
+                'name',
+            ],
+            'additionalProperties' => false,
+        ];
+
+        return $schema;
+    }
+}

--- a/tests/Contract/TestSchema.php
+++ b/tests/Contract/TestSchema.php
@@ -9,7 +9,7 @@ final readonly class TestSchema extends AbstractJsonSchema
     public static function schema(): array
     {
         $schema = [
-            '$schema' => 'http://json-schema.org/draft-07/schema#',
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
             'title' => 'Test',
             'type' => 'object',
             'properties' => [


### PR DESCRIPTION
**Issues**
- #27