### PR TITLE
[#32] Allow objects that implement `JsonSchemaInterface` to be represented as a PHP object

### DIFF
--- a/src/Contract/AbstractJsonSchema.php
+++ b/src/Contract/AbstractJsonSchema.php
@@ -2,6 +2,7 @@
 
 namespace OneToMany\RichBundle\Contract;
 
+use function json_decode;
 use function json_encode;
 use function strval;
 
@@ -14,6 +15,12 @@ abstract readonly class AbstractJsonSchema implements JsonSchemaInterface
     public function __toString(): string
     {
         return strval(json_encode(static::schema()));
+    }
+
+    public function asObject(): object
+    {
+        /** @var object */
+        return json_decode($this, false);
     }
 
     public function getName(): string

--- a/src/Contract/JsonSchemaInterface.php
+++ b/src/Contract/JsonSchemaInterface.php
@@ -11,6 +11,8 @@ interface JsonSchemaInterface extends \Stringable
      */
     public static function schema(): array;
 
+    public function asObject(): object;
+
     /**
      * @return non-empty-string
      */

--- a/src/Exception/Contract/WrappedExceptionSchema.php
+++ b/src/Exception/Contract/WrappedExceptionSchema.php
@@ -9,6 +9,7 @@ final readonly class WrappedExceptionSchema extends AbstractJsonSchema
     public static function schema(): array
     {
         return [
+            '$schema' => 'https://json-schema.org/draft/2020-12/schema',
             'title' => 'WrappedException',
             'type' => 'object',
             'properties' => [


### PR DESCRIPTION
**Issues**
- #32