### PR TITLE
[#58] Allow `HttpError` to indicate if the exception uses the `HasUserMessage` attribute

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
     },
     "require-dev": {
         "fakerphp/faker": "^1.24",
-        "friendsofphp/php-cs-fixer": "^3.84",
-        "phpstan/phpstan": "^2.1",
+        "friendsofphp/php-cs-fixer": "^3.86",
+        "phpstan/phpstan": "^2.1.22",
         "phpunit/phpunit": "^11.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "fakerphp/faker": "^1.24",
         "friendsofphp/php-cs-fixer": "^3.86",
         "phpstan/phpstan": "^2.1.22",
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^12.3.7"
     },
     "suggest": {
         "1tomany/data-uri": "Provides a data URI parser and file object for handling file uploads",

--- a/src/Contract/Error/HttpErrorInterface.php
+++ b/src/Contract/Error/HttpErrorInterface.php
@@ -55,5 +55,5 @@ interface HttpErrorInterface extends \Stringable
      */
     public function getTrace(): array;
 
-    public function getLevel(): string;
+    public function getLogLevel(): string;
 }

--- a/src/Contract/Error/HttpErrorInterface.php
+++ b/src/Contract/Error/HttpErrorInterface.php
@@ -9,7 +9,7 @@ use OneToMany\RichBundle\Contract\Enum\ErrorType;
  * @phpstan-type Trace array{class: ?string, function: ?string, file: ?string, line: ?int}
  * @phpstan-type Violation array{property: string, message: string}
  */
-interface HttpErrorInterface
+interface HttpErrorInterface extends \Stringable
 {
     public function getThrowable(): \Throwable;
 

--- a/src/Error/HttpError.php
+++ b/src/Error/HttpError.php
@@ -120,9 +120,21 @@ class HttpError implements HttpErrorInterface
         return $this->trace;
     }
 
-    public function getLevel(): string
+    public function getLogLevel(): string
     {
-        return $this->getStatus() >= 500 ? LogLevel::CRITICAL : LogLevel::ERROR;
+        if ($this->getStatus() < 300) {
+            return LogLevel::INFO;
+        }
+
+        if ($this->getStatus() < 400) {
+            return LogLevel::NOTICE;
+        }
+
+        if ($this->getStatus() < 500) {
+            return LogLevel::ERROR;
+        }
+
+        return LogLevel::CRITICAL;
     }
 
     public function hasUserMessage(): bool

--- a/src/Error/HttpError.php
+++ b/src/Error/HttpError.php
@@ -67,7 +67,7 @@ class HttpError implements HttpErrorInterface
      */
     public function __toString(): string
     {
-        return sprintf('(%s) %s', $this->getDescription(), $this->getMessage());
+        return sprintf('[%s] %s', $this->getDescription(), $this->getMessage());
     }
 
     public function getThrowable(): \Throwable

--- a/src/Error/HttpError.php
+++ b/src/Error/HttpError.php
@@ -27,30 +27,30 @@ use function trim;
  */
 class HttpError implements HttpErrorInterface
 {
-    private ErrorType $type;
+    protected ErrorType $type;
 
     /** @var int<100, 599> */
-    private int $status = 500;
+    protected int $status = 500;
 
     /** @var non-empty-string */
-    private string $title = 'Internal Server Error';
+    protected string $title = 'Internal Server Error';
 
     /** @var array<string, string> */
-    private array $headers = [];
+    protected array $headers = [];
 
     /** @var non-empty-string */
-    private string $message = 'An unexpected error occurred.';
+    protected string $message = 'An unexpected error occurred.';
 
     /** @var list<Violation> */
-    private array $violations = [];
+    protected array $violations = [];
 
     /** @var list<Stack> */
-    private array $stack = [];
+    protected array $stack = [];
 
     /** @var list<Trace> */
-    private array $trace = [];
+    protected array $trace = [];
 
-    public function __construct(private readonly \Throwable $throwable)
+    public function __construct(protected readonly \Throwable $throwable)
     {
         $this->resolveStatus();
         $this->resolveTitle();
@@ -117,7 +117,12 @@ class HttpError implements HttpErrorInterface
         return $this->getStatus() >= 500 ? LogLevel::CRITICAL : LogLevel::ERROR;
     }
 
-    private function resolveStatus(): void
+    public function hasUserMessage(): bool
+    {
+        return $this->hasAttribute(HasUserMessage::class);
+    }
+
+    protected function resolveStatus(): void
     {
         $status = (int) $this->throwable->getCode();
 
@@ -136,12 +141,12 @@ class HttpError implements HttpErrorInterface
         $this->status = max(100, min($status, 599));
     }
 
-    private function resolveTitle(): void
+    protected function resolveTitle(): void
     {
         $this->title = (Response::$statusTexts[$this->status] ?? null) ?: $this->title;
     }
 
-    private function resolveType(): void
+    protected function resolveType(): void
     {
         $hasErrorType = $this->getAttribute(...[
             'attributeClass' => HasErrorType::class,
@@ -157,7 +162,7 @@ class HttpError implements HttpErrorInterface
         }
     }
 
-    private function resolveHeaders(): void
+    protected function resolveHeaders(): void
     {
         $headers = null;
 
@@ -178,7 +183,7 @@ class HttpError implements HttpErrorInterface
         }
     }
 
-    private function resolveMessage(): void
+    protected function resolveMessage(): void
     {
         $message = null;
 
@@ -198,7 +203,7 @@ class HttpError implements HttpErrorInterface
         $this->message = trim($message ?? '') ?: $this->message;
     }
 
-    private function expandViolations(): void
+    protected function expandViolations(): void
     {
         $exception = $this->throwable;
 
@@ -216,7 +221,7 @@ class HttpError implements HttpErrorInterface
         }
     }
 
-    private function flattenStack(): void
+    protected function flattenStack(): void
     {
         $exception = $this->throwable;
 
@@ -232,7 +237,7 @@ class HttpError implements HttpErrorInterface
         }
     }
 
-    private function flattenTrace(): void
+    protected function flattenTrace(): void
     {
         foreach ($this->throwable->getTrace() as $trace) {
             $this->trace[] = [
@@ -251,7 +256,7 @@ class HttpError implements HttpErrorInterface
      *
      * @return ?T
      */
-    private function getAttribute(string $attributeClass): ?object
+    protected function getAttribute(string $attributeClass): ?object
     {
         $class = new \ReflectionClass($this->throwable);
 
@@ -267,7 +272,7 @@ class HttpError implements HttpErrorInterface
     /**
      * @param class-string $attributeClass
      */
-    private function hasAttribute(string $attributeClass): bool
+    protected function hasAttribute(string $attributeClass): bool
     {
         return null !== $this->getAttribute($attributeClass);
     }

--- a/src/Error/HttpError.php
+++ b/src/Error/HttpError.php
@@ -62,6 +62,14 @@ class HttpError implements HttpErrorInterface
         $this->resolveType();
     }
 
+    /**
+     * @return non-empty-string
+     */
+    public function __toString(): string
+    {
+        return sprintf('[%s] %s', $this->getDescription(), $this->getMessage());
+    }
+
     public function getThrowable(): \Throwable
     {
         return $this->throwable;

--- a/src/Error/HttpError.php
+++ b/src/Error/HttpError.php
@@ -67,7 +67,7 @@ class HttpError implements HttpErrorInterface
      */
     public function __toString(): string
     {
-        return sprintf('[%s] %s', $this->getDescription(), $this->getMessage());
+        return sprintf('(%s) %s', $this->getDescription(), $this->getMessage());
     }
 
     public function getThrowable(): \Throwable

--- a/tests/Error/HttpErrorTest.php
+++ b/tests/Error/HttpErrorTest.php
@@ -219,9 +219,15 @@ final class HttpErrorTest extends TestCase
     public function testConstructorResolvesType(): void
     {
         $exception = new \RuntimeException('Error');
-        $errorType = ErrorType::create($exception);
 
-        $this->assertSame($errorType, new HttpError($exception)->getType());
+        $this->assertSame(ErrorType::create($exception), new HttpError($exception)->getType());
+    }
+
+    public function testToString(): void
+    {
+        $httpError = new HttpError(new \RuntimeException('File not found.', 404));
+
+        $this->assertSame("[{$httpError->getDescription()}] {$httpError->getMessage()}", (string) $httpError);
     }
 
     public function testGettingThrowable(): void
@@ -257,13 +263,10 @@ final class HttpErrorTest extends TestCase
     public function testGettingTitleFromInvalidHttpStatus(): void
     {
         /** @var non-empty-string $title */
-        $title = Response::$statusTexts[
-            Response::HTTP_INTERNAL_SERVER_ERROR
-        ];
+        $title = Response::$statusTexts[Response::HTTP_INTERNAL_SERVER_ERROR];
 
-        $lastHttpStatus = array_key_last(
-            Response::$statusTexts
-        );
+        /** @var int $lastHttpStatus */
+        $lastHttpStatus = array_key_last(Response::$statusTexts);
 
         $httpStatus = random_int($lastHttpStatus + 1, $lastHttpStatus * 2);
         $this->assertArrayNotHasKey($httpStatus, Response::$statusTexts);

--- a/tests/Error/HttpErrorTest.php
+++ b/tests/Error/HttpErrorTest.php
@@ -254,11 +254,7 @@ final class HttpErrorTest extends TestCase
         /** @var non-empty-string $title */
         $title = Response::$statusTexts[$status];
 
-        // Arrange: Create Error Description
-        $description = "{$status} {$title}";
-
-        // Assert: Descriptions Match
-        $this->assertEquals($description, new HttpError(new HttpException($status))->getDescription());
+        $this->assertEquals("{$status} {$title}", new HttpError(new HttpException($status))->getDescription());
     }
 
     public function testGettingTitleFromInvalidHttpStatus(): void

--- a/tests/Error/HttpErrorTest.php
+++ b/tests/Error/HttpErrorTest.php
@@ -114,7 +114,7 @@ final class HttpErrorTest extends TestCase
     {
         $exception = new #[HasUserMessage] class('Error') extends \Exception {};
 
-        $this->assertEquals($exception->getMessage(), (new HttpError($exception))->getMessage());
+        $this->assertEquals($exception->getMessage(), new HttpError($exception)->getMessage());
     }
 
     public function testConstructorGeneralizesMessageWithAllOtherExceptions(): void

--- a/tests/Error/HttpErrorTest.php
+++ b/tests/Error/HttpErrorTest.php
@@ -228,7 +228,7 @@ final class HttpErrorTest extends TestCase
     {
         $httpError = new HttpError(new \RuntimeException('File not found.', 404));
 
-        $this->assertSame("({$httpError->getDescription()}) {$httpError->getMessage()}", (string) $httpError);
+        $this->assertSame("[{$httpError->getDescription()}] {$httpError->getMessage()}", (string) $httpError);
     }
 
     public function testGettingThrowable(): void

--- a/tests/Error/HttpErrorTest.php
+++ b/tests/Error/HttpErrorTest.php
@@ -228,7 +228,7 @@ final class HttpErrorTest extends TestCase
     {
         $httpError = new HttpError(new \RuntimeException('File not found.', 404));
 
-        $this->assertSame("[{$httpError->getDescription()}] {$httpError->getMessage()}", (string) $httpError);
+        $this->assertSame("({$httpError->getDescription()}) {$httpError->getMessage()}", (string) $httpError);
     }
 
     public function testGettingThrowable(): void

--- a/tests/Error/HttpErrorTest.php
+++ b/tests/Error/HttpErrorTest.php
@@ -296,6 +296,9 @@ final class HttpErrorTest extends TestCase
         $this->assertSame($logLevel, new HttpError($exception)->getLogLevel());
     }
 
+    /**
+     * @return list<list<int|string>>
+     */
     public static function providerStatusAndLogLevel(): array
     {
         $provider = [


### PR DESCRIPTION
**Issues**
- #58 