### PR TITLE
[#20] Create a `FailureHandler` class to allow stateless firewalls to render a response body when authentication fails

### DIFF
--- a/src/Security/FailureHandlerTrait.php
+++ b/src/Security/FailureHandlerTrait.php
@@ -7,7 +7,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
-trait FailureHandlerTrait // @phpstan-ignore trait.unused
+trait FailureHandlerTrait
 {
     /**
      * This method throws the original AuthenticationException to
@@ -20,6 +20,6 @@ trait FailureHandlerTrait // @phpstan-ignore trait.unused
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): never
     {
-        throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception);
+        throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception, code: 401);
     }
 }

--- a/src/Security/FailureHandlerTrait.php
+++ b/src/Security/FailureHandlerTrait.php
@@ -5,10 +5,20 @@ namespace OneToMany\RichBundle\Security;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
 trait FailureHandlerTrait // @phpstan-ignore trait.unused
 {
+    /**
+         * This method throws the original AuthenticationException to
+         * allow the user to invoke their own handler. Without it, the
+         * default Symfony exception handler is invoked and formats the
+         * response. By throwing the exception, we ensure that all API
+         * responses are consistently formatted.
+         *
+         * @throws HttpExceptionInterface
+         */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
     {
         throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception);

--- a/src/Security/FailureHandlerTrait.php
+++ b/src/Security/FailureHandlerTrait.php
@@ -10,14 +10,14 @@ use Symfony\Component\Security\Core\Exception\AuthenticationException;
 trait FailureHandlerTrait // @phpstan-ignore trait.unused
 {
     /**
-         * This method throws the original AuthenticationException to
-         * allow the user to invoke their own handler. Without it, the
-         * default Symfony exception handler is invoked and formats the
-         * response. By throwing the exception, we ensure that all API
-         * responses are consistently formatted.
-         *
-         * @throws HttpExceptionInterface
-         */
+     * This method throws the original AuthenticationException to
+     * allow the user to invoke their own handler. Without it, the
+     * default Symfony exception handler is invoked and formats the
+     * response. By throwing the exception, we ensure that all API
+     * responses are consistently formatted.
+     *
+     * @throws HttpExceptionInterface
+     */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): never
     {
         throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception);

--- a/src/Security/FailureHandlerTrait.php
+++ b/src/Security/FailureHandlerTrait.php
@@ -3,7 +3,6 @@
 namespace OneToMany\RichBundle\Security;
 
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -19,7 +18,7 @@ trait FailureHandlerTrait // @phpstan-ignore trait.unused
          *
          * @throws HttpExceptionInterface
          */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): never
     {
         throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception);
     }

--- a/src/Security/FailureHandlerTrait.php
+++ b/src/Security/FailureHandlerTrait.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OneToMany\RichBundle\Security;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+trait FailureHandlerTrait // @phpstan-ignore trait.unused
+{
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception): Response
+    {
+        throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception);
+    }
+}

--- a/src/Security/FailureHandlerTrait.php
+++ b/src/Security/FailureHandlerTrait.php
@@ -3,6 +3,7 @@
 namespace OneToMany\RichBundle\Security;
 
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -20,6 +21,6 @@ trait FailureHandlerTrait
      */
     public function onAuthenticationFailure(Request $request, AuthenticationException $exception): never
     {
-        throw HttpException::fromStatusCode(401, $exception->getMessage(), $exception, code: 401);
+        throw HttpException::fromStatusCode(Response::HTTP_UNAUTHORIZED, $exception->getMessage(), $exception, code: Response::HTTP_UNAUTHORIZED);
     }
 }

--- a/tests/Security/FailureHandlerTraitTest.php
+++ b/tests/Security/FailureHandlerTraitTest.php
@@ -6,7 +6,6 @@ use OneToMany\RichBundle\Security\FailureHandlerTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 

--- a/tests/Security/FailureHandlerTraitTest.php
+++ b/tests/Security/FailureHandlerTraitTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace OneToMany\RichBundle\Tests\Security;
+
+use OneToMany\RichBundle\Security\FailureHandlerTrait;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+final class FailureHandlerTraitTest extends TestCase
+{
+    use FailureHandlerTrait;
+
+    public function testOnAuthenticationFailureThrowsHttpException(): void
+    {
+        $authenticationExceptionMessage = 'Invalid credentials.';
+
+        $this->expectException(HttpExceptionInterface::class);
+        $this->expectExceptionCode(Response::HTTP_UNAUTHORIZED);
+        $this->expectExceptionMessage($authenticationExceptionMessage);
+
+        $this->onAuthenticationFailure(new Request(), new AuthenticationException($authenticationExceptionMessage));
+    }
+}


### PR DESCRIPTION
**Issues**
- #20

**Notes**
I ended up implementing this as a trait to avoid having to require the `symfony/security-http` package for the `Symfony\Component\Security\Http\Authentication\AuthenticationFailureHandlerInterface` interface.